### PR TITLE
Calculate OktaClient Content-Length correctly

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -552,7 +552,6 @@ func GetFactorId(f *OktaUserAuthnFactor) (id string, err error) {
 
 func (o *OktaClient) Get(method string, path string, data []byte, recv interface{}, format string) (err error) {
 	var res *http.Response
-	var body []byte
 	var header http.Header
 	var client http.Client
 
@@ -595,7 +594,7 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 		ProtoMinor:    1,
 		Header:        header,
 		Body:          ioutil.NopCloser(bytes.NewReader(data)),
-		ContentLength: int64(len(body)),
+		ContentLength: int64(len(data)),
 	}
 
 	if res, err = client.Do(req); err != nil {


### PR DESCRIPTION
Previously the content length was being calculated based off of an empty
uninitialised byte array. With this change it's now calculated off of the
actual data array used as the body.

Setting the content length to 0 seemed to be causing an issue with
recent changes to Okta's infrastructure as noticed in #298.